### PR TITLE
Fix #3

### DIFF
--- a/lib/src/llama_processor.dart
+++ b/lib/src/llama_processor.dart
@@ -76,7 +76,7 @@ class LlamaProcessor {
     ReceivePort isolateReceivePort = ReceivePort();
     mainSendPort.send(isolateReceivePort.sendPort);
 
-    Llama.libraryPath = args['libraryPath'] as String;
+    Llama.libraryPath = args['libraryPath'] as String?;
 
     Llama? llama;
     bool flagForStop = false;

--- a/lib/src/llama_processor.dart
+++ b/lib/src/llama_processor.dart
@@ -65,6 +65,7 @@ class LlamaProcessor {
           'modelParams': modelParams.toJson(),
           'contextParams': contextParams.toJson()
         });
+        _uninitialized.complete();
       } else if (message is String) {
         _controller.add(message);
       }

--- a/lib/src/llama_processor.dart
+++ b/lib/src/llama_processor.dart
@@ -50,7 +50,7 @@ class LlamaProcessor {
   Future<void> _loadModelIsolate() async {
     _modelIsolate = await Isolate.spawn(
       _modelIsolateEntryPoint,
-      _receivePort.sendPort,
+      {'port': _receivePort.sendPort, 'libraryPath': Llama.libraryPath},
     );
 
     _receivePort.listen((message) {
@@ -71,9 +71,12 @@ class LlamaProcessor {
   /// Entry point for the model isolate.
   ///
   /// Handles commands sent to the isolate, such as loading the model, generating text, and stopping the operation.
-  static void _modelIsolateEntryPoint(SendPort mainSendPort) {
+  static void _modelIsolateEntryPoint(Map<String, dynamic> args) {
+    SendPort mainSendPort = args['port'] as SendPort;
     ReceivePort isolateReceivePort = ReceivePort();
     mainSendPort.send(isolateReceivePort.sendPort);
+
+    Llama.libraryPath = args['libraryPath'] as String;
 
     Llama? llama;
     bool flagForStop = false;


### PR DESCRIPTION
Fixed the issue we had with Llama.libraryPath, its now working great in maid.

I also added some logic with a completer to prevent race conditions for when _modelSendport is uninitialized and either prompt, stop or unloadModel is called.