### PR TITLE
Export sampling params and update llama_processor

### DIFF
--- a/example/main.dart
+++ b/example/main.dart
@@ -5,6 +5,7 @@ import 'package:flutter/material.dart';
 import 'dart:io';
 import 'package:flutter/services.dart' show rootBundle;
 import 'package:llama_cpp_dart/llama_cpp_dart.dart';
+import 'package:llama_cpp_dart/src/sampling_params.dart';
 import 'package:path_provider/path_provider.dart';
 
 void main() async {
@@ -119,10 +120,11 @@ class _LandingPageState extends State<LandingPage> {
                   onPressed: () {
                     ModelParams modelParams = ModelParams();
                     ContextParams contextParams = ContextParams();
+                    SamplingParams samplingParams = SamplingParams();
                     contextParams.batch = 512;
                     contextParams.context = 512;
                     llamaProcessor = LlamaProcessor(
-                        _modelPathController.text, modelParams, contextParams);
+                        _modelPathController.text, modelParams, contextParams, samplingParams);
                     setState(() {
                       isModelLoaded = true;
                     });

--- a/lib/llama_cpp_dart.dart
+++ b/lib/llama_cpp_dart.dart
@@ -3,6 +3,7 @@ library;
 
 export 'src/model_params.dart';
 export 'src/context_params.dart';
+export 'src/sampling_params.dart';
 export 'src/llama.dart';
 export 'src/llama_processor.dart';
 export 'src/prompt_format.dart';

--- a/lib/src/llama.dart
+++ b/lib/src/llama.dart
@@ -61,6 +61,7 @@ class Llama {
 
   ContextParams contextParams;
   ModelParams modelParams;
+  SamplingParams? samplingParams;
 
   String loraBase;
   List<(String, double)> loraAdapters;
@@ -71,6 +72,7 @@ class Llama {
   Llama(String modelPath,
       [ModelParams? modelParams,
       ContextParams? contextParams,
+      this.samplingParams,
       this.loraBase = "",
       this.loraAdapters = const []])
       : modelParams = modelParams ?? ModelParams(),
@@ -173,7 +175,7 @@ class Llama {
   /// This function handles the selection and decoding of the next token.
   /// Returns a tuple with the generated text and a boolean indicating if the end-of-sequence token is reached.
   /// An exception is thrown if llama_decode fails during processing.
-  (String, bool) getNext([SamplingParams? samplingParams]) {
+  (String, bool) getNext() {
     samplingParams ??= SamplingParams();
 
     int newTokenId = 0;
@@ -202,7 +204,7 @@ class Llama {
       nativeLastTokens.elementAt(i).value = i;
     }
 
-    Pointer<llama_sampling_params> sp = samplingParams.get();
+    Pointer<llama_sampling_params> sp = samplingParams!.get();
     lib.llama_sample_repetition_penalties(
         context,
         candidatesP,

--- a/lib/src/llama_processor.dart
+++ b/lib/src/llama_processor.dart
@@ -3,9 +3,10 @@ import 'dart:isolate';
 
 import 'alpaca_format.dart';
 import 'chatml_format.dart';
-import 'model_params.dart';
 import 'prompt_format.dart';
+import 'model_params.dart';
 import 'context_params.dart';
+import 'sampling_params.dart';
 import 'llama.dart';
 
 /// The `LlamaProcessor` class handles the asynchronous operation of a Llama model in a separate isolate.
@@ -20,6 +21,9 @@ class LlamaProcessor {
 
   /// model parameters
   final ModelParams modelParams;
+
+  /// sampling parameters
+  final SamplingParams samplingParams;
 
   /// The isolate where the Llama model is loaded and run.
   late Isolate _modelIsolate;
@@ -43,7 +47,7 @@ class LlamaProcessor {
   /// Constructor for LlamaProcessor.
   ///
   /// Initializes the processor and starts the model isolate.
-  LlamaProcessor(this.path, this.modelParams, this.contextParams) {
+  LlamaProcessor(this.path, this.modelParams, this.contextParams, this.samplingParams) {
     _loadModelIsolate();
   }
 
@@ -68,7 +72,8 @@ class LlamaProcessor {
           'command': 'load',
           'path': path,
           'modelParams': modelParams.toJson(),
-          'contextParams': contextParams.toJson()
+          'contextParams': contextParams.toJson(),
+          'samplingParams': samplingParams.toJson(),
         });
         _uninitialized.complete();
       } else if (message is String) {
@@ -98,7 +103,9 @@ class LlamaProcessor {
                 ContextParams.fromJson(message['contextParams']);
             ModelParams modelParams =
                 ModelParams.fromJson(message['modelParams']);
-            llama = Llama(message['path'], modelParams, contextParams);
+            SamplingParams samplingParams =
+                SamplingParams.fromJson(message['samplingParams']);
+            llama = Llama(message['path'], modelParams, contextParams, samplingParams);
             break;
           case 'prompt':
             llama?.setPrompt(message['prompt']);


### PR DESCRIPTION
Added support for SamplingParams to LlamaProcessor.

Also added SamplingProcessor to the Llama constructor instead of passing it as a param to Llama.getNext(). You can change this back if you like but it makes prompting with the LlamaProcessor cleaner as this way SamplingParam doesn't need to be passed to the isolate for each prompt.

Not sure whats causing the merge conflict
