### PR TITLE
Fix LateInitializationError in Llama dispose method

### DIFF
--- a/lib/src/llama.dart
+++ b/lib/src/llama.dart
@@ -57,6 +57,7 @@ class Llama {
   int _nPos = 0;
 
   bool _verbos = false;
+  bool _isInitialized = false; // Track if initialization is complete
 
   bool _isDisposed = false;
   LlamaStatus _status = LlamaStatus.uninitialized;
@@ -101,11 +102,12 @@ class Llama {
       _initializeLlama(modelPath, mmprojPath, modelParamsDart,
           contextParamsDart, samplerParams);
 
-      if (contextParamsDart != null) {
-        var contextParams = contextParamsDart.get();
-        batch = lib.llama_batch_init(contextParams.n_batch, 0, 1);
-      }
+      // Always initialize the batch, even if contextParamsDart is null
+      contextParamsDart ??= ContextParams();
+      var contextParams = contextParamsDart.get();
+      batch = lib.llama_batch_init(contextParams.n_batch, 0, 1);
 
+      _isInitialized = true; // Mark initialization as complete
       _status = LlamaStatus.ready;
     } catch (e) {
       _status = LlamaStatus.error;
@@ -666,11 +668,22 @@ class Llama {
     if (_tokens != nullptr) malloc.free(_tokens);
     if (_tokenPtr != nullptr) malloc.free(_tokenPtr);
     if (_smpl != nullptr) lib.llama_sampler_free(_smpl);
-    if (context.address != 0) lib.llama_free(context);
-    if (model.address != 0) lib.llama_free_model(model);
+    
+    // Only access late fields if initialization was completed
+    if (_isInitialized) {
+      if (context.address != 0) lib.llama_free(context);
+      if (model.address != 0) lib.llama_free_model(model);
+      
+      // Free the batch only if it was initialized
+      try {
+        lib.llama_batch_free(batch);
+      } catch (e) {
+        // Batch not initialized, ignore
+      }
+    }
+    
     // if (_mctx != nullptr) lib.mtmd_free(_mctx); // <- crash - double free
 
-    lib.llama_batch_free(batch);
     lib.llama_backend_free();
 
     _isDisposed = true;
@@ -693,7 +706,7 @@ class Llama {
       _nPrompt = 0;
       _nPos = 0;
 
-      if (context.address != 0) {
+      if (_isInitialized && context.address != 0) {
         final mem = lib.llama_get_memory(context);
         lib.llama_memory_clear(mem, true);
       }


### PR DESCRIPTION
This commit fixes a critical bug that causes LateInitializationError when the Llama constructor fails during initialization.

Problem:
- dispose() method is called during constructor failure
- dispose() tries to access uninitialized late fields
- Results in LateInitializationError crash

Solution:
- Add _isInitialized flag to track initialization state
- Only access late fields in dispose() when initialization is complete
- Add try-catch around batch.free() for additional safety
- Ensure batch is always initialized to prevent null reference errors

Testing:
- Verified fix prevents crashes
- Maintains backward compatibility
- Allows graceful fallback to mock mode