### PR TITLE
feat: add embeddings function to llama parent

### DIFF
--- a/lib/src/isolate_parent.dart
+++ b/lib/src/isolate_parent.dart
@@ -47,6 +47,7 @@ class LlamaParent {
 
   Completer<void>? _readyCompleter;
   Completer<void>? _operationCompleter;
+  Completer<List<double>>? _embeddingsCompleter;
 
   /// Maps prompt IDs to completers for operation tracking
   final Map<String, Completer<void>> _promptCompleters = {};
@@ -79,6 +80,12 @@ class LlamaParent {
 
   /// Handle responses from the child isolate
   void _onData(LlamaResponse data) {
+    if (data.embeddings != null) {
+      if (_embeddingsCompleter != null && !_embeddingsCompleter!.isCompleted) {
+        _embeddingsCompleter!.complete(data.embeddings);
+        _embeddingsCompleter = null;
+      }
+    }
     // Update status if provided
     if (data.status != null) {
       _status = data.status!;
@@ -365,6 +372,11 @@ class LlamaParent {
     // Allow time for clear command to be processed
     await Future.delayed(const Duration(milliseconds: 100));
 
+    if (_embeddingsCompleter != null && !_embeddingsCompleter!.isCompleted) {
+      _embeddingsCompleter!.completeError(StateError("Parent disposed"));
+      _embeddingsCompleter = null;
+    }
+
     _parent.dispose();
   }
 
@@ -393,5 +405,17 @@ class LlamaParent {
 
     // Return a Future that completes when this prompt gets an ID
     return queuedPrompt.idCompleter.future;
+  }
+
+  Future<List<double>> getEmbeddings(String prompt) async {
+    if (!loadCommand.contextParams.embeddings) {
+      throw StateError(
+          "This LlamaParent instance is not configured for embeddings and can only generate text.");
+    }
+
+    _embeddingsCompleter = Completer();
+    _parent.sendToChild(id: 1, data: LlamaEmbedd(prompt));
+
+    return _embeddingsCompleter!.future;
   }
 }

--- a/lib/src/isolate_types.dart
+++ b/lib/src/isolate_types.dart
@@ -9,6 +9,12 @@ class LlamaStop extends LlamaCommand {}
 /// Command to clear the model context
 class LlamaClear extends LlamaCommand {}
 
+class LlamaEmbedd extends LlamaCommand {
+  final String prompt;
+
+  LlamaEmbedd(this.prompt);
+}
+
 /// Command to initialize the Llama library
 class LlamaInit extends LlamaCommand {
   final String? libraryPath;
@@ -37,6 +43,7 @@ class LlamaResponse {
   final String? promptId;
   final String? errorDetails;
   final bool isConfirmation;
+  final List<double>? embeddings;
 
   LlamaResponse({
     required this.text,
@@ -45,6 +52,7 @@ class LlamaResponse {
     this.promptId,
     this.errorDetails,
     this.isConfirmation = false,
+    this.embeddings,
   });
 
   /// Create a confirmation response


### PR DESCRIPTION
## 📌 Description

Problem: Llama parent doesn't currently support embedding models.

Solution: Allow Llama parent to work with embedding models so that they can be run in isolates and ensures a cohesive interface for chat and embedding models.  

This pull request adds support for using embedding models directly within the `LlamaParent` class of the `llama_cpp_dart` package. 

### ✨ Key Changes

- [ ] Introduced `getEmbeddings` method in `LlamaParent` which takes a user prompt and returns the vector embeddings for that prompt. This change allows embedding models to run in an isolate and to generate embeddings for RAG applications. 

## Notes 

  I've tested the implementation with multilingual-e5-large-instruct-q8_0.gguf embedding model on both Android and iOS within my Flutter application. 
  
- Please verify with other existing embedding models
---

## Usage Example

```
    final contextParams = ContextParams();
    contextParams.embeddings = true;

    final embedderLoadCommand = LlamaLoad(
      path: 'path to embedding model',
      modelParams: ModelParams(),
      contextParams: contextParams,
      samplingParams: SamplerParams(),
      format: ChatMLFormat(),
    );

    embedder = LlamaParent(embedderLoadCommand);

    await embedder.init();

    // Use embeddings to query a vector database etc. for RAG applications. 
    final List<double> embeddings = await embedder.getEmbeddings("Why is the sky blue?");
    ...
```