### PR TITLE
fix: interrupt generation on cancel (yield to event loop in worker decode loops)

### DIFF
--- a/lib/src/isolate/worker.dart
+++ b/lib/src/isolate/worker.dart
@@ -557,6 +557,10 @@ Future<void> _streamSampleAfterPrefill({
 
   try {
     while (true) {
+      // FIX: this synchronous decode loop never yields to the event loop, so a
+      // CancelCommand (an event-loop event) is starved and never registered
+      // mid-generation. Force one event-loop turn per token.
+      await Future<void>.delayed(Duration.zero);
       if (state.cancelledRequests.remove(requestId)) {
         cancelled = true;
         break;
@@ -823,6 +827,12 @@ Future<void> _streamSessionGenerate({
     shiftPolicy: shiftPolicy,
     shift: shift,
   )) {
+    // FIX: an async* generate stream delivers via microtasks; a CancelCommand
+    // arrives as an event-loop event. The tight yield→consume→decode loop never
+    // drains to the event loop, starving the cancel callback. Force one
+    // event-loop turn per token so a pending cancel is registered before this
+    // check.
+    await Future<void>.delayed(Duration.zero);
     if (state.cancelledRequests.remove(requestId)) {
       cancelled = true;
       break;


### PR DESCRIPTION
# fix: interrupt generation on cancel (yield to the event loop in the worker decode loops)

## Problem

Cancelling an in-flight `generate` stops token delivery but not the native
decode — the worker runs `llama_decode` to `maxTokens`/EOG regardless. After
cancelling at 10 tokens of a 400-token request, the KV cache is at position 411
(prompt + all 400). A subsequent generation has to wait behind the abandoned
one.

## Root cause

`async*` stream events are delivered via **microtasks**; a `CancelCommand`
arrives on the command port as an **event-loop event**. The tight
`yield → consume → decode` loop runs entirely in the microtask queue and never
drains to the event loop, so the `commandRx.listen` cancel callback
(`cancelledRequests.add`) is starved until the generation finishes. The loop's
`cancelledRequests` check is correct but never sees the cancel in time.

## Fix

Force one event-loop turn per token before the `cancelledRequests` check, in
both worker decode loops (`_streamSessionGenerate` and
`_streamSampleAfterPrefill`). A microtask yield is insufficient — it must reach
the event loop for the port message to be delivered — so
`await Future<void>.delayed(Duration.zero)`. No change to the existing
`CancelCommand` / `cancelledRequests` / `EngineGenerationCancelled` plumbing.

```diff
@@ _streamSampleAfterPrefill (while loop) @@
   try {
     while (true) {
+      await Future<void>.delayed(Duration.zero); // yield so a CancelCommand can register
       if (state.cancelledRequests.remove(requestId)) {
         cancelled = true;
         break;
       }
@@ _streamSessionGenerate (await for) @@
   )) {
+    await Future<void>.delayed(Duration.zero); // yield so a CancelCommand can register
     if (state.cancelledRequests.remove(requestId)) {
       cancelled = true;
       break;
     }
```

## Verification

macOS arm64 / Metal, SmolLM2-360M-Instruct Q4_K_M. Cancel a 1000-token
generation at 10 tokens, then time a fresh generation's first token:

```
cancel() issued at 10 tokens, 55 ms in
fresh gen first token after 25 ms   (without the fix: worker busy ~9677 ms)
```

`dart analyze` clean. Per-token overhead is negligible next to decode; happy to
switch to an every-N-tokens yield if preferred for max throughput on small
models.

(Full patch: `cancel-fix.patch` — `git apply` from the repo root.)

Fixes #105.
