### PR TITLE
fix(sampling): stop GBNF grammars from aborting the process

### DIFF
--- a/lib/src/generation/generator.dart
+++ b/lib/src/generation/generator.dart
@@ -59,8 +59,11 @@ final class Generator implements Finalizable {
       var generated = 0;
 
       while (true) {
+        // llama_sampler_sample() already calls llama_sampler_accept() on the
+        // token it selects, so accepting again here advanced every stateful
+        // sampler twice per token. That is a silent double-count for penalties
+        // and fatal for a grammar, which then sees the same piece twice.
         final token = sampler.sample(context);
-        sampler.accept(token);
 
         final bytes = tokenizer.encodeToken(token);
         final isEog = vocab.isEog(token);
@@ -181,7 +184,15 @@ final class Generator implements Finalizable {
         final isLast = isFinalChunk && j == end - 1;
         _batch.add(prompt[j], pos++, [request.seqId], wantLogits: isLast);
         // Inform stateful samplers (penalties etc) of the prompt context.
-        sampler.accept(prompt[j]);
+        //
+        // ...but NOT into a grammar. llama_sampler_chain_accept fans out to
+        // every stage, and a prompt does not parse as the answer grammar, so
+        // the grammar stack empties and llama_grammar_accept_token throws
+        // before a single token is sampled. A grammar must only ever see
+        // GENERATED tokens.
+        if (!request.sampler.grammar.enabled) {
+          sampler.accept(prompt[j]);
+        }
       }
       final rc = lib.llama_decode(context.pointer, _batch.raw);
       if (rc != 0) {

--- a/lib/src/isolate/worker.dart
+++ b/lib/src/isolate/worker.dart
@@ -648,8 +648,8 @@ Future<void> _streamSampleAfterPrefill({
         break;
       }
 
+      // See generator.dart: llama_sampler_sample() already accepted this.
       final token = samplerHandle.sample(ctx);
-      samplerHandle.accept(token);
       final isEog = state.model.vocab.isEog(token);
       final bytes = tokenizer.encodeToken(token);
 

--- a/lib/src/sampling/sampler_factory.dart
+++ b/lib/src/sampling/sampler_factory.dart
@@ -113,6 +113,18 @@ final class SamplerFactory {
       calloc.free(breakerPtrs);
     }
 
+    // The grammar must filter BEFORE the truncation stages. If top_k/top_p/
+    // min_p run first they discard candidates, the grammar then masks every
+    // survivor to -INFINITY, `dist` selects one regardless, and the accept
+    // inside llama_sampler_sample throws out of llama_grammar_accept_token —
+    // an uncaught C++ exception, so ggml_uncaught_exception calls abort().
+    // This matches llama.cpp's own common sampler, which applies the grammar
+    // first and samples from what survives. Truncation still runs, now over
+    // conforming candidates only.
+    if (params.grammar.enabled) {
+      _addGrammar(chain, params.grammar, requireVocab('grammar'));
+    }
+
     if (params.topNSigma > 0) {
       b.llama_sampler_chain_add(
         chain,
@@ -160,9 +172,6 @@ final class SamplerFactory {
     if (params.mirostat.enabled) {
       // Mirostat is terminal — no temp / dist after it.
       _addMirostat(chain, params, model);
-      if (params.grammar.enabled) {
-        _addGrammar(chain, params.grammar, requireVocab('grammar'));
-      }
       if (params.infill) {
         b.llama_sampler_chain_add(
           chain,
@@ -174,9 +183,6 @@ final class SamplerFactory {
 
     if (params.temperature <= 0.0) {
       // Temp <= 0 — pick argmax after the filters.
-      if (params.grammar.enabled) {
-        _addGrammar(chain, params.grammar, requireVocab('grammar'));
-      }
       if (params.infill) {
         b.llama_sampler_chain_add(
           chain,
@@ -201,10 +207,6 @@ final class SamplerFactory {
         chain,
         b.llama_sampler_init_temp(params.temperature),
       );
-    }
-
-    if (params.grammar.enabled) {
-      _addGrammar(chain, params.grammar, requireVocab('grammar'));
     }
 
     if (params.infill) {


### PR DESCRIPTION
Fixes #112.

Any `GrammarConfig` kills the host process — `abort()`, not an exception, so it cannot be caught from Dart, cannot be bounded by a timeout, and takes the whole app down. A 15-byte `root ::= "yes"` fails exactly like a real JSON schema, so it is not a grammar-authoring problem.

```
llama_sampler_chain_accept -> llama_grammar_accept_token -> __cxa_throw
  -> ggml_uncaught_exception -> abort()
```

llama.cpp throws when a token is accepted that the grammar cannot accept. Three places hand the grammar tokens it must never see. Isolated with a raw decode loop, one variable at a time — the first two abort on their own:

| prefill accepts prompt | explicit accept after sample | truncation before grammar | result |
| --- | --- | --- | --- |
| no | no | **yes** | abort |
| no | yes | yes | abort |
| **yes** | no | yes | abort — during prefill, before any token |
| no | no | no | valid grammar-conforming JSON |

## The three changes

**1. `sampler_factory.dart` — grammar before truncation.** The chain was `penalties -> top_k -> typical -> top_p -> min_p -> xtc -> temp -> grammar -> dist`. `top_k(40)` discards candidates first, the grammar masks every survivor to `-INFINITY`, `dist` selects one regardless, and the accept inside `llama_sampler_sample` throws on it. The grammar now filters before the truncation stages, which is what llama.cpp's own `common` sampler does. Truncation still runs, over conforming candidates only, so sampling quality is unchanged. The three later add sites are removed so every branch builds the same order.

**2. `generator.dart` `_prefill` — do not feed prompt tokens to a grammar.** `llama_sampler_chain_accept` fans out to every stage, and a prompt does not parse as the answer grammar, so this aborted during prefill regardless of sampler settings. Guarded rather than removed, so penalties keep prompt context on every non-grammar run.

This is the one callers cannot work around: `LlamaSession.generate` requires a pending prompt, so no public API path skips it and no `SamplerParams` value avoids it.

**3. `generator.dart` + `worker.dart` — drop the second accept.** `llama_sampler_sample()` already calls `llama_sampler_accept()` on the token it returns, so every stateful sampler advanced twice per token. Silent double-count for penalties; fatal for a grammar, which sees the same piece twice.

The bottom row of the table is the direct evidence for this: with no explicit accept at all, the grammar still advanced correctly and produced well-formed nested JSON across 58 tokens — which is only possible if `sample()` was accepting internally.

For precision about what was measured: I did not isolate whether #3 aborts *by itself*, because #1 fires first in every configuration that has it. It is a correctness bug independently.

## Verification

These same three changes were applied to `0.9.0-dev.9` and shipped in a Flutter app, run on macOS/arm64 against `Qwen3-0.6B-Q4_0` through `LlamaEngine.spawnFromProcess`:

```json
{"readings": [{"label":"Blood pressure","value":128,"unit":"mmHg", "confidence": 0.95}]}
```

```json
{"observations": [
   {"type":"pain","description":"left shoulder pain with a possible impact on the morning after"},
   {"type":"fatigue", "description":"increased fatigue in the afternoon"}
]}
```

Both Hangul range notations behave identically (a literal range, and the `\uAC00-\uD7AF` escape form) — the notation was never relevant, which is worth stating because it is the natural first suspect.

Nine on-device integration cases pass, all asserting. Unconstrained generation is unaffected: a translation smoke and a structured-output smoke that use plain `generate()` both still pass in the same run, so dropping the double accept does not degrade normal sampling.

`dart analyze lib` reports the same issue count before and after this branch.

I have no way to run your CI matrix locally, so please re-run the full suite — in particular anything covering penalties or mirostat, since change #3 alters how often stateful samplers are advanced.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

